### PR TITLE
Change default version in extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -61,7 +61,7 @@
 			"value": []
 		},
 		"ScratchBlocks4BlockVersion": {
-			"value": "1.0"
+			"value": "snap"
 		}
 	},
 	"manifest_version": 2,


### PR DESCRIPTION
This gets exposed to run_scratchblocks4.js and can be changed by individual wikis.