### PR TITLE
Move translations and main snapblocks library code to ext.snapblocks ReourceLoader module

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -19,26 +19,11 @@
 	"ResourceModules": {
 		"ext.snapblocks": {
 			"scripts": [
-				"run_snapblocks.js"
-			],
-			"styles": "/inline.css",
-			"dependencies": [
-				"ext.snapblocks.sb",
-				"ext.snapblocks.translations"
-			]
-		},
-		"ext.snapblocks.sb": {
-			"scripts": [
-				"lib/snapblocks.min.js"
-			]
-		},
-		"ext.snapblocks.translations": {
-			"scripts": [
+				"run_snapblocks.js",
+				"lib/snapblocks.min.js",
 				"lib/translations-all.js"
 			],
-			"dependencies": [
-				"ext.snapblocks.sb"
-			]
+			"styles": "/inline.css",
 		}
 	},
 	"ResourceFileModulePaths": {


### PR DESCRIPTION
This allows us to load less modules, which should help speed up loading times slightly as MediaWiki has to deal with less metadata now.